### PR TITLE
PHP dependencies update.(20191217)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "3bf671629a3b2a5a5694f8dfee15686e586b33b6"
+                "reference": "4e326d030ef7c82585d276969b3079169b4806e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3bf671629a3b2a5a5694f8dfee15686e586b33b6",
-                "reference": "3bf671629a3b2a5a5694f8dfee15686e586b33b6",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4e326d030ef7c82585d276969b3079169b4806e2",
+                "reference": "4e326d030ef7c82585d276969b3079169b4806e2",
                 "shasum": ""
             },
             "require": {
@@ -42,7 +42,8 @@
                 "nette/neon": "^2.3",
                 "phpunit/phpunit": "^4.8.35|^5.4.3",
                 "psr/cache": "^1.0",
-                "psr/simple-cache": "^1.0"
+                "psr/simple-cache": "^1.0",
+                "sebastian/comparator": "^1.2.3"
             },
             "suggest": {
                 "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
@@ -87,7 +88,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-11-26T19:08:40+00:00"
+            "time": "2019-12-16T19:10:16+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -141,12 +142,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "cc98cfb202fdcbe36fdf7c7ba28d94df9657bb40"
+                "reference": "27ed75d7234a04e18b19138ea1e07b8efc5f9bbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/cc98cfb202fdcbe36fdf7c7ba28d94df9657bb40",
-                "reference": "cc98cfb202fdcbe36fdf7c7ba28d94df9657bb40",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/27ed75d7234a04e18b19138ea1e07b8efc5f9bbd",
+                "reference": "27ed75d7234a04e18b19138ea1e07b8efc5f9bbd",
                 "shasum": ""
             },
             "require": {
@@ -194,7 +195,7 @@
             "keywords": [
                 "google"
             ],
-            "time": "2019-11-07T18:42:16+00:00"
+            "time": "2019-12-04T16:27:44+00:00"
         },
         {
             "name": "google/apiclient-services",
@@ -286,16 +287,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.4.1",
+            "version": "6.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "0895c932405407fd3a7368b6910c09a24d26db11"
+                "reference": "dbc2bc3a293ed6b1ae08a3651e2bfd213d19b6a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/0895c932405407fd3a7368b6910c09a24d26db11",
-                "reference": "0895c932405407fd3a7368b6910c09a24d26db11",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/dbc2bc3a293ed6b1ae08a3651e2bfd213d19b6a5",
+                "reference": "dbc2bc3a293ed6b1ae08a3651e2bfd213d19b6a5",
                 "shasum": ""
             },
             "require": {
@@ -310,12 +311,13 @@
                 "psr/log": "^1.1"
             },
             "suggest": {
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.3-dev"
+                    "dev-master": "6.5-dev"
                 }
             },
             "autoload": {
@@ -348,7 +350,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2019-10-23T15:58:00+00:00"
+            "time": "2019-12-07T18:20:45+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -478,12 +480,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "11fb4f92702f98577c95c8ea1e61b937f8f70859"
+                "reference": "38449de333489cd0498a047c27c9c6f1845f52ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/11fb4f92702f98577c95c8ea1e61b937f8f70859",
-                "reference": "11fb4f92702f98577c95c8ea1e61b937f8f70859",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/38449de333489cd0498a047c27c9c6f1845f52ed",
+                "reference": "38449de333489cd0498a047c27c9c6f1845f52ed",
                 "shasum": ""
             },
             "require": {
@@ -551,7 +553,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2019-11-15T14:56:08+00:00"
+            "time": "2019-12-11T21:01:17+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",


### PR DESCRIPTION
PHP dependencies update.
The bellow packages will be updated.

| package | required by | before | current |
| ---- | ---- | ---- | ---- |
| aws/aws-sdk-php |  | -- | 9999999-dev |
| firebase/php-jwt | google/apiclient<br>google/auth | -- | 5.0.0.0 |
| google/apiclient |  | -- | 9999999-dev |
| google/apiclient-services | google/apiclient | -- | 0.121.0.0 |
| google/auth | google/apiclient | -- | 1.6.1.0 |
| guzzlehttp/guzzle | aws/aws-sdk-php<br>google/apiclient<br>google/auth | -- | 6.5.0.0 |
| guzzlehttp/promises | aws/aws-sdk-php<br>guzzlehttp/guzzle | -- | 1.3.1.0 |
| guzzlehttp/psr7 | aws/aws-sdk-php<br>google/apiclient<br>google/auth<br>guzzlehttp/guzzle | -- | 1.6.1.0 |
| monolog/monolog | google/apiclient | -- | 9999999-dev |
| mtdowling/jmespath.php | aws/aws-sdk-php | -- | 2.4.0.0 |
| phpseclib/phpseclib | google/apiclient | -- | 2.0.23.0 |
| psr/cache | google/auth | -- | 1.0.1.0 |
| psr/http-message | google/auth<br>guzzlehttp/psr7 | -- | 1.0.1.0 |
| psr/log | monolog/monolog | -- | 1.1.2.0 |
| ralouphie/getallheaders | guzzlehttp/psr7 | -- | 3.0.3.0 |
